### PR TITLE
Add: opp name format enforcement

### DIFF
--- a/GroupProject/.idea/misc.xml
+++ b/GroupProject/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/GroupProject/app/src/main/java/group1/pittapi/PittScores.java
+++ b/GroupProject/app/src/main/java/group1/pittapi/PittScores.java
@@ -66,7 +66,11 @@ public class PittScores extends AppCompatActivity {
             ScoreData sd = new ScoreData();
             sd.setPittScore(Integer.parseInt(extras.getString("PittScore")));
             sd.setOppScore(Integer.parseInt(extras.getString("OppScore")));
-            sd.setOppName(extras.getString("OppName"));
+            try {
+                sd.setOppName(extras.getString("OppName"));
+            } catch (Exception e){
+                Log.w("SET_OPP_NAME", e.toString());
+            }
 
             //Shows dialog:
             // Cancel button: closes this activity

--- a/GroupProject/app/src/main/java/group1/pittapi/ScoreData.java
+++ b/GroupProject/app/src/main/java/group1/pittapi/ScoreData.java
@@ -1,5 +1,7 @@
 package group1.pittapi;
 
+import android.util.Log;
+
 /**
  * Created by billyhinard on 3/23/18.
  */
@@ -27,10 +29,42 @@ public class ScoreData {
 
     public void setOppName(String name) {
         this.oppName = name;
+
+        for(team enumName : team.values()) {
+            if (name.equalsIgnoreCase(enumName.toString())){
+                oppName = enumName.toString();
+                Log.w("OPPONENT FOUND: ", "Setting OPP Image");
+            }
+        }
+
+        if (oppName.equals("")) {
+            Log.w("OPPONENT NOT FOUND: ", "Reverting to plain text");
+            oppName = name;
+        }
+
+
     }
 
     public String getOppName() {
         return oppName;
+    }
+
+    public enum team {
+        PENN_STATE,
+        BOSTON_COLLEGE,
+        CLEMSON,
+        FLORIDA_STATE,
+        LOUISVILLE,
+        NC_STATE,
+        NOTRE_DAME,
+        SYRACUSE,
+        WAKE_FOREST,
+        DUKE,
+        GEORGIA_TECH,
+        MIAMI,
+        UNC,
+        VIRGINIA,
+        VIRGINIA_TECH
     }
 
 


### PR DESCRIPTION
Added enum 'team' class in Score data for opponent name format enforcement.

Diff: detected diff in GroupProject/.idea/misc.xml

   -Lang_Level from 1_8 to 1_7. 
   -Closing issues to adjust to 1_8 and re pushing branch